### PR TITLE
Fix for dist.now = NA causing "if (dist.now < mindistsofar)" to crash…

### DIFF
--- a/R/kbal.R
+++ b/R/kbal.R
@@ -213,9 +213,9 @@ kbal=function(X,D, K=NULL, whiten=FALSE, trimratio=NULL, numdims=NULL,
       dist.record=c(dist.record,dist.now)
       thisnumdims=thisnumdims+incrementby
 
-      if (dist.now<mindistsofar){mindistsofar=dist.now}
+      if (dist.now < mindistsofar & is.na(dist.now) == FALSE){mindistsofar=dist.now}
       wayover=(dist.now/mindistsofar)>1.25
-      keepgoing=(dist.now>dist.min) & (dist.now!=999) & thisnumdims<=maxnumdims & wayover==FALSE
+      keepgoing=(dist.now>dist.min) & (dist.now!=999) & thisnumdims<=maxnumdims & wayover==FALSE & (is.na(dist.now) == FALSE)
       # XXX error above? dist.min not defined?
     }
 


### PR DESCRIPTION
… KBAL

I've described the issue identification in more detail on the tjbal issue page. To be short, there is a problem within ebalance_custom where the eb() function returns a vector of weights with one element equal to NA, another equal to one, and the rest equal to zero. This causes pX_D0w in get.dist to be assigned a value of NA. As a result, dist.now is assigned NA and this crashes KBAL because  "if (dist.now < mindistsofar)" cannot be evaluated. 

The proposed fix here adds the additional constraint that dist.now is not NA. In the case that dist.now is NA the fix will cause KBAL to exit the while loop and use the mindist that had be calculated up until dist.now returned NA.

I want to reiterate that this is a temporary fix for a root issue with eb() within the ebalance_custom() function. I apologize for not knowing what exactly the root issue is because I'm not certain why ebalance would return a weight equal to NA.