### PR TITLE
fix typo in DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 0.1
 Date: 2020-02-14
 Authors@R: c(person("Chad", "Hazlett", email = "chazlett@ucla.edu", role = c("aut", "cre")),
             person("Ciara", "Sterbenz", email = "cster@g.ucla.edu", role = "aut"),
-            person("Erin", "Hartman", email = "ekhartman@ucla.edu", role = "ctb"))
+            person("Erin", "Hartman", email = "ekhartman@ucla.edu", role = "ctb"),
             person("Alex", "Kravetz", email = "alexdkravetz@gmail.com", role = "ctb"))
 Description: A weighting approach the employs kernels to make one group
     have a similar distribution to another group on covariates


### PR DESCRIPTION
My mistake, this was introduced in the last PR.  I've installed the library from this branch and confirmed it works as expected